### PR TITLE
Release 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Contributors: Brandon Fuller, Sarah Pucino
 Tags: themes  
 Requires at least: 4.0  
 Tested up to: 4.9  
-Stable tag: 1.2.1  
+Stable tag: 1.2.2  

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 URI Modern Magazine is a WordPress theme designed for the University of Rhode Island Magazine site. It is a child theme of URI Modern.
 
+## What's new in 1.2.2
+
+URI Modern Magazine 1.2.2 is a bug fix release.
+
+* Fixes the order of architecture tags so that the parent category is first
+
 ## How do I get set up?
 
 1. Make sure you have [URI Modern](https://github.com/uriweb/uri-modern) installed first

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uri-modern-magazine",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "URI Modern Magazine is a WordPress theme designed for the University of Rhode Island Magazine site. It is a child theme of URI Modern.",
   "themeName": "URI Modern Magazine",
   "textDomain": "uri",

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@ Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: URI Modern Magazine is a WordPress theme designed for the University of Rhode Island Magazine site. It is a child theme of URI Modern.
 Template: uri-modern
-Version: 1.2.1
+Version: 1.2.2
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v1.2.1
+@version v1.2.2
 @author Brandon Fuller <bjcfuller@uri.edu>
 
 */

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -23,7 +23,7 @@
 
 		$args = array(
 			'orderby'  => 'parent',
-			'order'    => 'ASC'
+			'order'    => 'ASC',
 		);
 
 		$post_architecture = get_terms( 'architecture', $args );

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -21,7 +21,12 @@
 		<div class="architecture">
 		<?php
 
-		$post_architecture = get_the_terms( $the_post, 'architecture' );
+		$args = array(
+			'orderby'  => 'parent',
+			'order'    => 'ASC'
+		);
+
+		$post_architecture = get_terms( 'architecture', $args );
 
 		foreach ( $post_architecture as $p ) {
 			if ( ! empty( $p ) ) {


### PR DESCRIPTION
## What's new in 1.2.2

URI Modern Magazine 1.2.2 is a bug fix release.

* Fixes the order of architecture tags so that the parent category is first