### PR TITLE
Hotfix 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 URI Modern Magazine is a WordPress theme designed for the University of Rhode Island Magazine site. It is a child theme of URI Modern.
 
-## What's new in 1.2.2
+## What's new in 1.2.3
 
-URI Modern Magazine 1.2.2 is a bug fix release.
+URI Modern Magazine 1.2.3 is a hotfix release.
 
-* Fixes the order of architecture tags so that the parent category is first
+* Ensures only taxonomy of the current post is displayed
 
 ## How do I get set up?
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Contributors: Brandon Fuller, Sarah Pucino
 Tags: themes  
 Requires at least: 4.0  
 Tested up to: 4.9  
-Stable tag: 1.2.2  
+Stable tag: 1.2.3  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uri-modern-magazine",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "URI Modern Magazine is a WordPress theme designed for the University of Rhode Island Magazine site. It is a child theme of URI Modern.",
   "themeName": "URI Modern Magazine",
   "textDomain": "uri",

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@ Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: URI Modern Magazine is a WordPress theme designed for the University of Rhode Island Magazine site. It is a child theme of URI Modern.
 Template: uri-modern
-Version: 1.2.2
+Version: 1.2.3
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v1.2.2
+@version v1.2.3
 @author Brandon Fuller <bjcfuller@uri.edu>
 
 */

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -26,7 +26,7 @@
 			'order'    => 'ASC',
 		);
 
-		$post_architecture = get_terms( 'architecture', $args );
+		$post_architecture = wp_get_object_terms( get_the_ID(), 'architecture', $args );
 
 		foreach ( $post_architecture as $p ) {
 			if ( ! empty( $p ) ) {


### PR DESCRIPTION
## What's new in 1.2.3

URI Modern Magazine 1.2.3 is a hotfix release.

* Ensures only taxonomy of the current post is displayed